### PR TITLE
Fix strict-mode declaration error

### DIFF
--- a/lib/bytestream.js
+++ b/lib/bytestream.js
@@ -18,7 +18,7 @@
  * @param {number=} opt_length The length of this BitStream
  * @constructor
  */
-ByteStream = function(ab, opt_offset, opt_length) {
+var ByteStream = function(ab, opt_offset, opt_length) {
     var offset = opt_offset || 0;
     var length = opt_length || ab.byteLength;
     this.bytes = new Uint8Array(ab, offset, length);


### PR DESCRIPTION
The existing code works in Node, but errors in [strict mode evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), like in Vite, which converts CJS modules to ESM for use in the browser.